### PR TITLE
fix: default worker count

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "controller_flavor" {
 variable "worker_count" {
   type = number
   description = "number of workers"
-  default = 2
+  default = 4
 }
 
 variable "worker_image" {


### PR DESCRIPTION
Due to anti affinitty rules and the type of deployments, if there are less than 3 workers components of genestack will fail. I ran into this specifically with deploying rabbitmq