### PR TITLE
feat: Add providernet to tofu lab builds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -403,7 +403,6 @@ resource "openstack_networking_port_v2" "compute-provider-ports" {
   name               = format("compute%02d.%s", count.index + 1, var.cluster_name)
   network_id         = openstack_networking_network_v2.osflex-provider.id
   admin_state_up     = "true"
-  security_group_ids = [openstack_networking_secgroup_v2.secgroup-flex-providernet.id]
   fixed_ip {
     subnet_id = openstack_networking_subnet_v2.osflex-provider-subnet.id
   }
@@ -460,7 +459,6 @@ resource "openstack_networking_port_v2" "network-provider-ports" {
   name               = format("network%02d.%s", count.index + 1, var.cluster_name)
   network_id         = openstack_networking_network_v2.osflex-provider.id
   admin_state_up     = "true"
-  security_group_ids = [openstack_networking_secgroup_v2.secgroup-flex-providernet.id]
   fixed_ip {
     subnet_id = openstack_networking_subnet_v2.osflex-provider-subnet.id
   }

--- a/main.tf
+++ b/main.tf
@@ -64,12 +64,6 @@ resource "openstack_networking_secgroup_v2" "secgroup-flex-nodes" {
   name = "openstack-flex-nodes"
 }
 
-## Create management network security group for flex providernet
-# Create sec group
-resource "openstack_networking_secgroup_v2" "secgroup-flex-providernet" {
-  name = "openstack-flex-providernet"
-}
-
 ## Create management network security group node rule for local TCP access
 # Create sec group rule
 resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-permit-tcp-local" {
@@ -78,13 +72,6 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-permit
   security_group_id = openstack_networking_secgroup_v2.secgroup-flex-nodes.id
   protocol          = "tcp"
   remote_ip_prefix  = "172.31.0.0/22"
-}
-resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-providernet-permit-tcp-local" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  security_group_id = openstack_networking_secgroup_v2.secgroup-flex-providernet.id
-  protocol          = "tcp"
-  remote_ip_prefix  = "192.168.200.0/23"
 }
 
 ## Create management network security group node rule for local UDP access
@@ -96,13 +83,6 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-permit
   protocol          = "udp"
   remote_ip_prefix  = "172.31.0.0/22"
 }
-resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-providernet-permit-udp-local" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  security_group_id = openstack_networking_secgroup_v2.secgroup-flex-providernet.id
-  protocol          = "udp"
-  remote_ip_prefix  = "192.168.200.0/23"
-}
 
 ## Create management network security group node rule for public HTTP access
 # Create sec group rule
@@ -110,15 +90,6 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-public
   direction         = "ingress"
   ethertype         = "IPv4"
   security_group_id = openstack_networking_secgroup_v2.secgroup-flex-nodes.id
-  protocol          = "tcp"
-  port_range_min    = "80"
-  port_range_max    = "80"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-providernet-public-http" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  security_group_id = openstack_networking_secgroup_v2.secgroup-flex-providernet.id
   protocol          = "tcp"
   port_range_min    = "80"
   port_range_max    = "80"
@@ -136,15 +107,6 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-public
   port_range_max    = "443"
   remote_ip_prefix  = "0.0.0.0/0"
 }
-resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-providernet-public-https" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  security_group_id = openstack_networking_secgroup_v2.secgroup-flex-providernet.id
-  protocol          = "tcp"
-  port_range_min    = "443"
-  port_range_max    = "443"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
 
 ## Create management network security group node rule for public icmp echo requests
 # Create sec group rule
@@ -152,13 +114,6 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-flex-node-public
   direction         = "ingress"
   ethertype         = "IPv4"
   security_group_id = openstack_networking_secgroup_v2.secgroup-flex-nodes.id
-  protocol          = "icmp"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-resource "openstack_networking_secgroup_rule_v2" "secgroup-rule-providernet-public-ping" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  security_group_id = openstack_networking_secgroup_v2.secgroup-flex-providernet.id
   protocol          = "icmp"
   remote_ip_prefix  = "0.0.0.0/0"
 }

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "openstack_networking_network_v2" "osflex-provider" {
   name                  = "osflex-provider"
   admin_state_up        = "true"
   external              = false
-  port_security_enabled = true
+  port_security_enabled = false
 }
 
 # Create Neutron Provider Subnet

--- a/main.tf
+++ b/main.tf
@@ -621,7 +621,7 @@ resource "openstack_networking_floatingip_v2" "mlbflips" {
   port_id = openstack_networking_port_v2.mlbvips[count.index].id
 }
 
-# Create floating ip for provider_vips
+# Create floating ips for provider_vips
 resource "openstack_networking_floatingip_v2" "providerflips" {
   count   = length(var.provider_vips)
   pool    = "PUBLICNET"

--- a/main.tf
+++ b/main.tf
@@ -407,12 +407,6 @@ resource "openstack_networking_port_v2" "compute-provider-ports" {
   fixed_ip {
     subnet_id = openstack_networking_subnet_v2.osflex-provider-subnet.id
   }
-  dynamic "allowed_address_pairs" {
-    for_each = toset(var.provider_vips)
-    content {
-      ip_address = allowed_address_pairs.value
-    }
-  }
 }
 
 # Create compute nodes
@@ -469,12 +463,6 @@ resource "openstack_networking_port_v2" "network-provider-ports" {
   security_group_ids = [openstack_networking_secgroup_v2.secgroup-flex-providernet.id]
   fixed_ip {
     subnet_id = openstack_networking_subnet_v2.osflex-provider-subnet.id
-  }
-  dynamic "allowed_address_pairs" {
-    for_each = toset(var.provider_vips)
-    content {
-      ip_address = allowed_address_pairs.value
-    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -220,9 +220,6 @@ resource "openstack_compute_instance_v2" "k8s-controller" {
   network {
     name = openstack_networking_network_v2.osflex-k8s-overlay.name
   }
-  network {
-    name = openstack_networking_network_v2.osflex-neutron-overlay.name
-  }
   metadata = {
     hostname = format("kubernetes%02d", count.index + 1)
     group    = "openstack-flex"
@@ -262,9 +259,6 @@ resource "openstack_compute_instance_v2" "openstack-controller" {
   network {
     name = openstack_networking_network_v2.osflex-k8s-overlay.name
   }
-  network {
-    name = openstack_networking_network_v2.osflex-neutron-overlay.name
-  }
   metadata = {
     hostname     = format("controller%02d", count.index + 1)
     group        = "openstack-flex"
@@ -303,9 +297,6 @@ resource "openstack_compute_instance_v2" "openstack-worker" {
   }
   network {
     name = openstack_networking_network_v2.osflex-k8s-overlay.name
-  }
-  network {
-    name = openstack_networking_network_v2.osflex-neutron-overlay.name
   }
   metadata = {
     hostname     = format("worker%02d", count.index + 1)
@@ -430,9 +421,6 @@ resource "openstack_compute_instance_v2" "storage-node" {
   network {
     name = openstack_networking_network_v2.osflex-k8s-overlay.name
   }
-  network {
-    name = openstack_networking_network_v2.osflex-neutron-overlay.name
-  }
   metadata = {
     hostname     = format("storage%02d", count.index + 1)
     group        = "openstack-flex"
@@ -471,9 +459,6 @@ resource "openstack_compute_instance_v2" "ceph-node" {
   }
   network {
     name = openstack_networking_network_v2.osflex-k8s-overlay.name
-  }
-  network {
-    name = openstack_networking_network_v2.osflex-neutron-overlay.name
   }
   metadata = {
     hostname = format("ceph%02d", count.index + 1)

--- a/scripts/inventorier.py
+++ b/scripts/inventorier.py
@@ -18,7 +18,7 @@ storage_prefix = 'storage'
 ceph_prefix = 'ceph'
 cluster_name = 'cluster.local'
 kube_ovn_iface = 'enp4s0'
-mgmt_network = 'openstack-flex'
+mgmt_network = 'osflex-mgmt'
 
 servers = os.list_servers()
 

--- a/scripts/lab_inventory.py
+++ b/scripts/lab_inventory.py
@@ -72,7 +72,7 @@ def inventory_data(servers):
         inventory.add_group(group)
 
     for server in servers:
-        ip_address = server['addresses']['openstack-flex'][0]['addr']
+        ip_address = server['addresses']['osflex-mgmt'][0]['addr']
         host = Host(server.name)
         host.vars = {'ansible_host': ip_address, 'ip': "'{{ ansible_host }}'"}
         if 'role' in server.metadata:
@@ -134,7 +134,7 @@ class LabInventory:
 
     def add_host_to_hostvars(self, server):
         """Adds server to hostvars"""
-        server_ip = server['addresses']['openstack-flex'][0]['addr']
+        server_ip = server['addresses']['osflex-mgmt'][0]['addr']
         self.inventory['_meta']['hostvars'].update({server.name: {'ansible_host': server_ip,
                                                                   'ip': server_ip}})
 
@@ -144,7 +144,7 @@ class LabInventory:
 
     def get_floating_ip_from_server(self, server: Type[openstack.compute.v2.server.Server]) -> str:
         """Gets the floating ip from server.  It will return the first one or none"""
-        for item in server['addresses']['openstack-flex']:
+        for item in server['addresses']['osflex-mgmt']:
             if item['OS-EXT-IPS:type'] == 'floating':
                 return item['addr']
         return None

--- a/variables.tf
+++ b/variables.tf
@@ -152,8 +152,15 @@ variable "cluster_name" {
   description = "Name of the cluster"
   default = "cluster.local"
 }
+
 variable "mlb_vips" {
   type = list(string)
   description = "VIPs to create for Metal LB, should not overlap with subnet allocation pool!"
   default = ["172.31.3.1", "172.31.3.2", "172.31.3.3"]
+}
+
+variable "provider_vips" {
+  type = list(string)
+  description = "VIPs to create for compute provider network (used for double NAT)"
+  default = ["192.168.200.101", "192.168.200.102", "192.168.200.103"]
 }


### PR DESCRIPTION
The default build layout left some additional network configuration to be desired, mainly when setting up the inner cloud's provider network there was no easy way to route real external internet traffic to the internal cloud's neutron routers. This change simply dedicates the pre-existing enp5s0 interface as a "neutron overlay network" which could be used if desired for east/west VM connectivity solely for Neutron geneve traffic (though this would require advanced configuration not covered here or in Genestack documentation). Consider it reserved for future use at the moment.

A separate provider network (enp6s0) is added and connected to the osflex-router. The idea is that one will create a flat provider network on the inner cloud sharing the same subnet as the osflex-provider-subnet. This allows for a double NAT configuration so that FLIPs from the outercloud can NAT to IPs designated on the inner cloud's PUBLICNET subnet allocation pool (which should be configured with the same range defined in the variables.tf (provider_vips).

Some renaming has taken place to hopefully help alleviate confusion when looking at resources.

Note: You may need to remove the extra default route added to network and compute nodes:

    ansible -m shell -a 'sudo ip route del default via 192.168.200.1 dev enp6s0' all --limit 'network0*'

**Example LAB Network Architecture**
![osflex-provider-example](https://github.com/user-attachments/assets/dd5f02f9-b5ba-460a-a7ed-a61a4d15b778)



